### PR TITLE
Optimized docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the application
-FROM maven:3.9.4-eclipse-temurin-17 AS build
+FROM maven:3.9.4-eclipse-temurin-17 AS builder
 
 # Set the working directory inside the container
 WORKDIR /app
@@ -10,6 +10,9 @@ COPY src ./src
 
 # Build the application
 RUN mvn clean package -DskipTests
+ARG JAR_FILE=target/*.jar
+COPY ${JAR_FILE} application.jar
+RUN java -Djarmode=tools -jar application.jar extract --layers --destination application
 
 # Stage 2: Create the final runtime container
 FROM eclipse-temurin:17-jre
@@ -18,10 +21,13 @@ FROM eclipse-temurin:17-jre
 WORKDIR /app
 
 # Copy the JAR file from the build stage
-COPY --from=build /app/target/*.jar app.jar
+COPY --from=builder /app/application/dependencies/ ./
+COPY --from=builder /app/application/snapshot-dependencies/ ./
+COPY --from=builder /app/application/spring-boot-loader/ ./
+COPY --from=builder /app/application/application/ ./
 
 # Expose the application port
 EXPOSE 8080
 
 # Run the application
-ENTRYPOINT ["java", "-Xmx96m", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Xmx96m", "-jar", "application.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,9 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
+                    <layers>
+                        <enabled>true</enabled>
+                    </layers>
                     <excludes>
                         <exclude>
                             <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
By utilizing the layers feature in spring-boot we can extract those layers and include them in our image one layer at a time.  This will allow us to cache more of the application so that our uploads to dockerhub are much smaller and it can cache more between images.